### PR TITLE
Bugfix: adjust CSS to prevent layout shifting

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -165,7 +165,7 @@
     padding-top: var(--font-scale-3);
     font-size: var(--font-scale-3);
     display: flex;
-    grid-column-start: 2;
+    flex-grow: 1;
   }
 
   .grid {

--- a/src/app.css
+++ b/src/app.css
@@ -97,6 +97,7 @@ h1 {
   height: 100%;
   overflow-x: hidden;
   width: 100vw;
+  scrollbar-gutter: stable both-edges;
 }
 
 button {

--- a/src/lib/tabnav/Tabs.svelte
+++ b/src/lib/tabnav/Tabs.svelte
@@ -56,3 +56,9 @@
   <div class="spacer" />
   <slot />
 </div>
+
+<style>
+  .tabs {
+    flex-grow: 1;
+  }
+</style>


### PR DESCRIPTION
The header was shifting on both the x and y axis depending on the amount of content.
The y-axis issue was fixed by ensuring the content flexbox always takes up the remaining space.
The x-axis issue was resolved by including the scroll bar in the width calculation.